### PR TITLE
use AWS CLI tools, fix S3.put_object signature

### DIFF
--- a/src/S3.jl
+++ b/src/S3.jl
@@ -444,7 +444,7 @@ function restore_object(env::AWSEnv, bkt::AbstractString, key::AbstractString, d
 end
 
 
-function put_object(env::AWSEnv, bkt::AbstractString, key::AbstractString, data:: Union{IOStream, AbstractString, Tuple}; content_type="", options::PutObjectOptions=PutObjectOptions(), version_id::AbstractString="")
+function put_object(env::AWSEnv, bkt::AbstractString, key::AbstractString, data:: Union{IO, AbstractString, Tuple}; content_type="", options::PutObjectOptions=PutObjectOptions(), version_id::AbstractString="")
     ro = RO(:PUT, bkt, key)
 
     ro.amz_hdrs = amz_headers(Tuple[], options)


### PR DESCRIPTION
The AWS CLI tools will honor the following variables:
- AWS_ACCESS_KEY_ID
- AWS_SECRET_ACCESS_KEY
- AWS_DEFAULT_REGION

This commit updates the package to do the same, while preserving
existing defaults and extending the configuration-file alternative
to include specifying a region.