### PR TITLE
fixed convert when S3 returns error, issue #29

### DIFF
--- a/src/S3.jl
+++ b/src/S3.jl
@@ -634,8 +634,8 @@ function do_request(env::AWSEnv, ro::RO; conv_to_string=true)
     if (http_resp.status > 299)
         if  (search(Base.get(http_resp.headers, "Content-Type", [""]), "/xml") != 0:-1)
             s3_resp.obj = S3Error(LightXML.root(LightXML.parse_string(bytestring(http_resp.data))))
-		else
-			s3_resp.pd = bytestring(http_resp.data)
+	else
+	    s3_resp.pd = bytestring(http_resp.data)
         end
     else
         s3_resp.obj = conv_to_string ? bytestring(http_resp.data) : http_resp.data

--- a/src/S3.jl
+++ b/src/S3.jl
@@ -634,8 +634,8 @@ function do_request(env::AWSEnv, ro::RO; conv_to_string=true)
     if (http_resp.status > 299)
         if  (search(Base.get(http_resp.headers, "Content-Type", [""]), "/xml") != 0:-1)
             s3_resp.obj = S3Error(LightXML.root(LightXML.parse_string(bytestring(http_resp.data))))
-	else
-	    s3_resp.pd = bytestring(http_resp.data)
+        else
+            s3_resp.pd = bytestring(http_resp.data)
         end
     else
         s3_resp.obj = conv_to_string ? bytestring(http_resp.data) : http_resp.data

--- a/src/S3.jl
+++ b/src/S3.jl
@@ -632,11 +632,8 @@ function do_request(env::AWSEnv, ro::RO; conv_to_string=true)
     s3_resp.headers = http_resp.headers
 
     if (http_resp.status > 299)
-        if  (search(Base.get(http_resp.headers, "Content-Type", [""]), "/xml") != 0:-1) && isa(http_resp.data, IO) && (position(http_resp.data) > 0)
-            s3_resp.pd = LightXML.root(LightXML.parse_string(bytestring(http_resp.data)))
-            if s3_resp.pd.name == "Error"
-                s3_resp.obj = S3Error(s3_resp.pd)
-            end
+        if  (search(Base.get(http_resp.headers, "Content-Type", [""]), "/xml") != 0:-1)
+            s3_resp.obj = S3Error(LightXML.root(LightXML.parse_string(bytestring(http_resp.data))))
 		else
 			s3_resp.pd = bytestring(http_resp.data)
         end
@@ -895,9 +892,3 @@ rfc1123_date(d::Void) = nothing
 
 
 end
-
-
-
-
-
-

--- a/src/s3_types.jl
+++ b/src/s3_types.jl
@@ -608,6 +608,16 @@ end
 function S3Error(pde)
     code = LightXML.content(LightXML.find_element(pde, "Code"))
     message = LightXML.content(LightXML.find_element(pde, "Message"))
+    
+    # this might be redundant as it often returns empty, AWS docs 
+    # at http://docs.aws.amazon.com/AmazonS3/latest/API/ErrorResponses.html
+    # are incomplete
+    _resrce = LightXML.find_element(pde, "Resource")
+    resource =  _resrce != Void() ? LightXML.content(_resrce) : Void()
+
+    _sig = LightXML.find_element(pde, "SignatureProvided")
+    signature =  _sig != Void() ? LightXML.content(_sig) : Void()
+
     hostId = LightXML.content(LightXML.find_element(pde, "HostId"))
     requestId = LightXML.content(LightXML.find_element(pde, "RequestId"))
 

--- a/src/s3_types.jl
+++ b/src/s3_types.jl
@@ -602,19 +602,18 @@ CORSConfiguration(pd) = AWS.@parse_vector(AWS.S3.CORSRule, LightXML.get_elements
 type S3Error
     code::Union{AbstractString, Void}
     message::Union{AbstractString, Void}
-    resource::Union{AbstractString, Void}
     hostId::Union{AbstractString, Void}
     requestId::Union{AbstractString, Void}
 end
 function S3Error(pde)
     code = LightXML.content(LightXML.find_element(pde, "Code"))
     message = LightXML.content(LightXML.find_element(pde, "Message"))
-    resource = LightXML.content(LightXML.find_element(pde, "Resource"))
     hostId = LightXML.content(LightXML.find_element(pde, "HostId"))
     requestId = LightXML.content(LightXML.find_element(pde, "RequestId"))
 
-    S3Error(code, message, resource, hostId, requestId)
+    S3Error(code, message, hostId, requestId)
 end
+
 export CORSConfiguration
 
 


### PR DESCRIPTION
Only a couple of minor changes were required to fix conversion errors when credentials are invalid, incorrectly specified, requesting bucket contents for non-existent buckets. 

The error can now be found in the http_resp.obj as an AWS.S3.S3Error object.